### PR TITLE
Add support for multiple tfms and a packages.lock.json

### DIFF
--- a/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/FrameworkDependencyResolver.cs
+++ b/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/FrameworkDependencyResolver.cs
@@ -67,7 +67,7 @@ namespace Afas.BazelDotnet.Nuget
             continue;
           }
 
-          var existingPackageIsEmpty = existingPackage.RefItemGroups.SingleOrDefault()?.Items.Any() != true;
+          var existingPackageIsEmpty = existingPackage.RefItemGroups.FirstOrDefault()?.Items.Any() != true;
           if(existingPackageIsEmpty || packageOverride >= existingPackage.Version)
           {
             if(frameworkList.TryGetValue(id, out var frameworkItem))
@@ -121,7 +121,7 @@ namespace Afas.BazelDotnet.Nuget
 
       bool OverridesAssemblyVersion(NugetRepositoryEntry package, Version frameworkListVersion)
       {
-        var refItems = package.RefItemGroups.Single();
+        var refItems = package.RefItemGroups.First();
         if(!refItems.Items.Any())
         {
           return true;

--- a/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/LocalPackageExtractor.cs
+++ b/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/LocalPackageExtractor.cs
@@ -19,9 +19,9 @@ namespace Afas.BazelDotnet.Nuget
     private readonly SourceCacheContext _cache;
     private readonly PackageExtractionContext _context;
 
-    public LocalPackageExtractor(ISettings settings, ILogger logger, SourceCacheContext cache)
+    public LocalPackageExtractor(ISettings settings, NuGetv3LocalRepository v3LocalRepository, ILogger logger, SourceCacheContext cache)
     {
-      _v3LocalRepository = new NuGetv3LocalRepository(SettingsUtility.GetGlobalPackagesFolder(settings), new LocalPackageFileCache(), false);
+      _v3LocalRepository = v3LocalRepository;
       _cache = cache;
       _context = new PackageExtractionContext(PackageSaveMode.Defaultv3, XmlDocFileSaveMode.Skip, ClientPolicyContext.GetClientPolicy(settings, logger), logger);
     }
@@ -31,11 +31,11 @@ namespace Afas.BazelDotnet.Nuget
     {
       if(!_v3LocalRepository.Exists(packageIdentity.Id, packageIdentity.Version))
       {
-        var packageDependency = await provider.GetPackageDownloaderAsync(packageIdentity, _cache, _context.Logger, CancellationToken.None);
+      var downloader = await provider.GetPackageDownloaderAsync(packageIdentity, _cache, _context.Logger, CancellationToken.None);
 
         var installed = await PackageExtractor.InstallFromSourceAsync(
           packageIdentity,
-          packageDependency,
+          downloader,
           _v3LocalRepository.PathResolver,
           _context,
           CancellationToken.None,

--- a/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/NugetRepositoryEntryBuilder.cs
+++ b/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/NugetRepositoryEntryBuilder.cs
@@ -13,24 +13,12 @@ namespace Afas.BazelDotnet.Nuget
   internal class NugetRepositoryEntryBuilder
   {
     private readonly ManagedCodeConventions _conventions;
-    private readonly List<FrameworkRuntimePair> _targets;
+    private readonly IReadOnlyCollection<FrameworkRuntimePair> _targets;
 
-    public NugetRepositoryEntryBuilder(ManagedCodeConventions conventions)
+    public NugetRepositoryEntryBuilder(ManagedCodeConventions conventions, IReadOnlyCollection<FrameworkRuntimePair> targets)
     {
       _conventions = conventions;
-      _targets = new List<FrameworkRuntimePair>();
-    }
-
-    public NugetRepositoryEntryBuilder WithTarget(FrameworkRuntimePair target)
-    {
-      _targets.Add(target);
-      return this;
-    }
-
-    public NugetRepositoryEntryBuilder WithTarget(NuGetFramework target)
-    {
-      _targets.Add(new FrameworkRuntimePair(target, runtimeIdentifier: null));
-      return this;
+      _targets = targets;
     }
 
     public NugetRepositoryEntry ResolveGroups(LocalPackageSourceInfo localPackageSourceInfo)

--- a/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/NugetRepositoryEntryBuilder.cs
+++ b/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/NugetRepositoryEntryBuilder.cs
@@ -156,7 +156,7 @@ namespace Afas.BazelDotnet.Nuget
       newEntry.DependencyGroups.AddRange(entry.DependencyGroups);
       if(frameworkOverride != null)
       {
-        newEntry.RefItemGroups.Add(new FrameworkSpecificGroup(_targets.Single().Framework, new []
+        newEntry.RefItemGroups.Add(new FrameworkSpecificGroup(_targets.First().Framework, new []
         {
           frameworkOverride,
         }));

--- a/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/NugetRepositoryEntryBuilder.cs
+++ b/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/NugetRepositoryEntryBuilder.cs
@@ -79,9 +79,19 @@ namespace Afas.BazelDotnet.Nuget
           new PatternDefinition("analyzers/{assembly}")
         });
 
+        // "2.0.0/build/netstandard2.0/ref/netstandard.dll"
+        var netstandardRefAssemblies = new PatternSet(_conventions.Properties, new []
+        {
+          new PatternDefinition("build/{tfm}/ref/{any?}"),
+        }, new[]
+        {
+          new PatternDefinition("build/{tfm}/ref/{assembly}"),
+        });
+
         AddIfNotNull(entry.RefItemGroups, target.Framework,
           collection.FindBestItemGroup(criteria,
             _conventions.Patterns.CompileRefAssemblies,
+            netstandardRefAssemblies,
             _conventions.Patterns.CompileLibAssemblies)
           ?.Items);
 

--- a/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/NugetRepositoryGenerator.cs
+++ b/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/NugetRepositoryGenerator.cs
@@ -115,7 +115,7 @@ string_flag(
       var runtimeGraph = dependencyGraphs.Select(g => g.RuntimeGraph).Aggregate(RuntimeGraph.Merge);
       var entryBuilder = new NugetRepositoryEntryBuilder(new ManagedCodeConventions(runtimeGraph), rootProject.Targets);
 
-      var localPackages = await dependencyGraphResolver.DownloadPackages(dependencyGraphs).ConfigureAwait(false);
+      var localPackages = await dependencyGraphResolver.DownloadPackages(dependencyGraphs.Take(2)).ConfigureAwait(false);
       var entries = localPackages.Select(entryBuilder.ResolveGroups).ToArray();
 
       var (frameworkEntries, frameworkOverrides) = await new FrameworkDependencyResolver(dependencyGraphResolver)

--- a/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/RootProject.cs
+++ b/src/Afas.BazelDotnet.Nuget/BazelDotnet.Nuget/RootProject.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.DependencyResolver;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.RuntimeModel;
+using NuGet.Versioning;
+
+namespace Afas.BazelDotnet.Nuget
+{
+  internal class RootProject
+  {
+    private const string _rootProjectName = "Root";
+    private const string _rootProjectVersion = "1.0.0";
+    private readonly Lazy<bool> _isLockFileValid;
+
+    public RootProject(IReadOnlyCollection<FrameworkRuntimePair> targets, IReadOnlyCollection<LibraryRange> dependencies, PackagesLockFile nugetLockFile = null)
+    {
+      Targets = targets;
+      NugetLockFile = nugetLockFile;
+      PackageSpec = PrepareRootProject(targets, dependencies);
+      _isLockFileValid = new Lazy<bool>(() =>
+      {
+        if(NugetLockFile == null)
+        {
+          return false;
+        }
+
+        DependencyGraphSpec spec = new DependencyGraphSpec().CreateFromClosure(_rootProjectName, new [] { PackageSpec });
+        return PackagesLockFileUtilities.IsLockFileValid(spec, NugetLockFile).IsValid;
+      });
+    }
+
+    public IReadOnlyCollection<FrameworkRuntimePair> Targets { get; }
+
+    public PackageSpec PackageSpec { get; }
+
+    public PackagesLockFile NugetLockFile { get; }
+
+    public string Name => _rootProjectName;
+
+    public string Version => _rootProjectVersion;
+
+    public bool IsLockFileValid => _isLockFileValid.Value;
+
+    private static PackageSpec PrepareRootProject(IReadOnlyCollection<FrameworkRuntimePair> targets, IReadOnlyCollection<LibraryRange> dependencies) =>
+      new PackageSpec(targets.Select(t => new TargetFrameworkInformation { FrameworkName = t.Framework }).ToArray())
+      {
+        Name = _rootProjectName,
+        Version = NuGetVersion.Parse(_rootProjectVersion),
+        Dependencies = dependencies.Select(package => new LibraryDependency
+          {
+            LibraryRange = package,
+            Type = LibraryDependencyType.Build,
+            IncludeType = LibraryIncludeFlags.None,
+            SuppressParent = LibraryIncludeFlags.All,
+            AutoReferenced = true,
+            GeneratePathProperty = false,
+          })
+          .ToList(),
+        RestoreMetadata = new ProjectRestoreMetadata { ProjectUniqueName = _rootProjectName },
+        RuntimeGraph = new RuntimeGraph(targets.Where(t => !string.IsNullOrEmpty(t.RuntimeIdentifier)).Select(t => new RuntimeDescription(t.RuntimeIdentifier)).Distinct())
+      };
+  }
+}

--- a/src/Afas.BazelDotnet.Project/BazelDotnet.Project/CsProjectFileDefinition.cs
+++ b/src/Afas.BazelDotnet.Project/BazelDotnet.Project/CsProjectFileDefinition.cs
@@ -13,10 +13,7 @@ namespace Afas.BazelDotnet.Project
     public CsProjectFileDefinition(string projectFilePath, string slnBasePath)
     {
       RelativeFilePath = Path.GetRelativePath(slnBasePath, projectFilePath);
-      PackageReferences = new List<string>
-      {
-        "Microsoft.NETCore.App.Ref",
-      };
+      PackageReferences = new List<string>();
       ProjectReference = new List<string>();
       BazelData = new List<string>();
       EmbeddedResources = new List<EmbeddedResourceDefinition>();
@@ -48,6 +45,13 @@ namespace Afas.BazelDotnet.Project
       var projectFileDir = Path.GetDirectoryName(projectFilePath);
 
       Type = GetProjectType(_document);
+
+      var targetFramework = _document.Descendants("TargetFramework").FirstOrDefault()?.Value;
+      var targetFrameworkRef = string.Equals("netstandard2.0", targetFramework, StringComparison.OrdinalIgnoreCase)
+        ? "Netstandard.Library"
+        : "Microsoft.NETCore.App.Ref";
+
+      PackageReferences.Add(targetFrameworkRef);
 
       foreach(var reference in _document.Descendants("PackageReference"))
       {

--- a/src/Afas.BazelDotnet/BazelDotnet/Program.cs
+++ b/src/Afas.BazelDotnet/BazelDotnet/Program.cs
@@ -27,7 +27,7 @@ namespace Afas.BazelDotnet
       app.Command("repository", repoCmd =>
       {
         var nugetConfig = repoCmd.Argument("nugetConfig", "The path to the Packages.Props file");
-        var tfmOption = repoCmd.Option("-t|--tfm", "The target framework to restore", CommandOptionType.SingleOrNoValue);
+        var tfmOption = repoCmd.Option("-t|--tfm", "The target framework to restore", CommandOptionType.MultipleValue);
         var packageProps = repoCmd.Option("-p|--package", "Packages.Props files", CommandOptionType.MultipleValue);
         var importsOption = repoCmd.Option("-i|--imports", "Import files with dictionary of imported project labels (PackageName=Label)", CommandOptionType.MultipleValue);
 
@@ -35,8 +35,8 @@ namespace Afas.BazelDotnet
         {
           var packagePropsFilePaths = packageProps.Values.Select(v => Path.Combine(Directory.GetCurrentDirectory(), v)).ToArray();
           var nugetConfigFilePath = Path.Combine(Directory.GetCurrentDirectory(), nugetConfig.Value);
-          var tfm = tfmOption.HasValue() ? tfmOption.Value() : "net5.0";
-          await WriteRepository(tfm, packagePropsFilePaths, nugetConfigFilePath, importsOption.Values).ConfigureAwait(false);
+          IReadOnlyList<string> tfms = tfmOption.HasValue() ? tfmOption.Values : new [] { "net5.0" };
+          await WriteRepository(tfms, packagePropsFilePaths, nugetConfigFilePath, importsOption.Values).ConfigureAwait(false);
           return 0;
         });
       });
@@ -130,7 +130,7 @@ namespace Afas.BazelDotnet
         !arg.version.EndsWith("-local-dev", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static async Task WriteRepository(string tfm, IEnumerable<string> packagePropsFiles, string nugetConfig, IReadOnlyCollection<string> importMappings = null)
+    private static async Task WriteRepository(IReadOnlyList<string> tfms, IEnumerable<string> packagePropsFiles, string nugetConfig, IReadOnlyCollection<string> importMappings = null)
     {
       // Note: no conlict resolution. Maybe we can add them in the dep graph. For now multiple Packages.Props is not really a use case anymore
       (string, string)[] deps = packagePropsFiles
@@ -142,7 +142,7 @@ namespace Afas.BazelDotnet
         .ToLookup(i => i.project, i => (i.target, i.configSetting), StringComparer.OrdinalIgnoreCase);
 
       await new NugetRepositoryGenerator(nugetConfig, imports)
-        .WriteRepository(tfm, "win-x64", deps)
+        .WriteRepository(tfms, "win-x64", deps)
         .ConfigureAwait(false);
     }
 

--- a/src/Afas.BazelDotnet/BazelDotnet/Program.cs
+++ b/src/Afas.BazelDotnet/BazelDotnet/Program.cs
@@ -27,6 +27,7 @@ namespace Afas.BazelDotnet
       app.Command("repository", repoCmd =>
       {
         var nugetConfig = repoCmd.Argument("nugetConfig", "The path to the Packages.Props file");
+        var nugetLockFile = repoCmd.Option("-l|--lock", "Nuget lock file", CommandOptionType.SingleOrNoValue);
         var tfmOption = repoCmd.Option("-t|--tfm", "The target framework to restore", CommandOptionType.MultipleValue);
         var packageProps = repoCmd.Option("-p|--package", "Packages.Props files", CommandOptionType.MultipleValue);
         var importsOption = repoCmd.Option("-i|--imports", "Import files with dictionary of imported project labels (PackageName=Label)", CommandOptionType.MultipleValue);
@@ -35,8 +36,9 @@ namespace Afas.BazelDotnet
         {
           var packagePropsFilePaths = packageProps.Values.Select(v => Path.Combine(Directory.GetCurrentDirectory(), v)).ToArray();
           var nugetConfigFilePath = Path.Combine(Directory.GetCurrentDirectory(), nugetConfig.Value);
+          var nugetLockFilePath = nugetLockFile.HasValue() ? Path.Combine(Directory.GetCurrentDirectory(), nugetLockFile.Value()) : null;
           IReadOnlyList<string> tfms = tfmOption.HasValue() ? tfmOption.Values : new [] { "net5.0" };
-          await WriteRepository(tfms, packagePropsFilePaths, nugetConfigFilePath, importsOption.Values).ConfigureAwait(false);
+          await WriteRepository(tfms, packagePropsFilePaths, nugetConfigFilePath, nugetLockFilePath, importsOption.Values).ConfigureAwait(false);
           return 0;
         });
       });
@@ -130,7 +132,7 @@ namespace Afas.BazelDotnet
         !arg.version.EndsWith("-local-dev", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static async Task WriteRepository(IReadOnlyList<string> tfms, IEnumerable<string> packagePropsFiles, string nugetConfig, IReadOnlyCollection<string> importMappings = null)
+    private static async Task WriteRepository(IReadOnlyList<string> tfms, IEnumerable<string> packagePropsFiles, string nugetConfig, string nugetLockFilePath, IReadOnlyCollection<string> importMappings = null)
     {
       // Note: no conlict resolution. Maybe we can add them in the dep graph. For now multiple Packages.Props is not really a use case anymore
       (string, string)[] deps = packagePropsFiles
@@ -142,7 +144,7 @@ namespace Afas.BazelDotnet
         .ToLookup(i => i.project, i => (i.target, i.configSetting), StringComparer.OrdinalIgnoreCase);
 
       await new NugetRepositoryGenerator(nugetConfig, imports)
-        .WriteRepository(tfms, "win-x64", deps)
+        .WriteRepository(tfms, "win-x64", deps, nugetLockFilePath)
         .ConfigureAwait(false);
     }
 


### PR DESCRIPTION
This PR adds support for targeting netstandard which is required to build source generators .

This PR adds support for multiple target frameworks in a mono-repo setup to target netX and netstandard together.

This PR also adds support for a packages.lock.json file similar to https://devblogs.microsoft.com/nuget/enable-repeatable-package-restores-using-a-lock-file/